### PR TITLE
参照名を変更

### DIFF
--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -227,7 +227,7 @@
     $(M,N)$のMulEquivを$M \simeq* N$と略記する．
 \end{definition}
 
-\begin{definition}\label{quotientKerEquivRange}\lean{quotientKerEquivRange}\leanok
+\begin{definition}\label{quotientKerEquivRange}\lean{QuotientGroup.quotientKerEquivRange}\leanok
     $ G , G' $を群とし，$ \phi : G \to G' $を群準同型とする．この時，
     \begin{align}
         G/\ker\phi &\cong \phi(G)


### PR DESCRIPTION
\lean{} の中に入れる参照名が間違っていました.  \lea{quotientKerEquivRange} ではなく\lean{EquiQuotientGroup.quotientKerEquivRange} とする必要がありました.